### PR TITLE
Added dependency on autoprefixer-rails for transition to work

### DIFF
--- a/less-rails-semantic_ui.gemspec
+++ b/less-rails-semantic_ui.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency     'less-rails', '~> 2.6.0', '>= 2.6.0'
+  spec.add_runtime_dependency     'autoprefixer-rails', '~> 0.7'
 
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
Very useful gem! :+1: 

I think transition requires `autoprefixer` to work (which happened in my project).  This pull request adds that into the gemspec.